### PR TITLE
Add OCR-based fallback for standings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ lxml==5.2.1
 html5lib==1.1
 beautifulsoup4==4.12.3
 urllib3==2.2.1
+pillow==10.3.0
+pytesseract==0.3.10


### PR DESCRIPTION
## Summary
- add Pillow and pytesseract dependencies for OCR
- support manual standings via screenshot if scraping fails
- include upload page and route

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683f545e517c8324ad87289cef8259d7